### PR TITLE
Pizza overhead branch

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -1,0 +1,19 @@
+ChangeLog
+
+	Fixes by Linuxgurugamer:
+
+	Fixed node value being saved in Persisor.cs, line 457, was saving the vesselState as a vesselSituation
+	Fixed a nullref when entering the editor, nullref was because constructionPlaylist
+		was empty, and it appears that the game code is assuming there is always a playlist
+	Fixed Nullref in SoundGui.cs when sted.ActivePlaylists was null
+	Added InstallChecker to validate correct installation (untested)
+
+
+
+The following changes were done using the ToolbarController, so it is not in
+this version:
+	Made left click open/close the player, right-click open the main gui
+	Protected click-through through the windows to the scene below using the
+		ClickThroughBlocker
+	Added ability to put the button on either the stock toolbar or Blizzy's
+		toolbar, using the ToolbarController

--- a/SoundtrackEditor/AudioLoader.cs
+++ b/SoundtrackEditor/AudioLoader.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using UnityEngine;
+using UnityEngine.Networking;
 using System.IO;
 
 namespace SoundtrackEditor
@@ -38,7 +39,7 @@ namespace SoundtrackEditor
                     {
                         case ".WAV":
                         case ".OGG":
-                            return LoadUnityAudioClip(file);
+                            return LoadUnityAudioClip(ext.ToUpperInvariant(), file);
                         case ".MP3":
                             return LoadMp3Clip(file);
                         default:
@@ -80,14 +81,15 @@ namespace SoundtrackEditor
             return files;
         }
 
-        private static AudioClip LoadUnityAudioClip(string filePath)
+        private static AudioClip LoadUnityAudioClip(string ftype, string filePath)
         {
             try
             {
-                Utils.Log("Loading Unity clip");
+                Utils.Log("Loading Unity clip: " + filePath);
                 // Load the audio clip into memory.
                 WWW www = new WWW("file://" + filePath);
-                AudioClip clip = UnityEngine.WWWAudioExtensions.GetAudioClip(www);
+                AudioClip clip = www.GetAudioClip();
+
                 clip.name = Path.GetFileNameWithoutExtension(filePath);
                 Utils.Log("Clip name: " + clip.name + ", load state: " + clip.loadState);
                 return clip;

--- a/SoundtrackEditor/EventManager.cs
+++ b/SoundtrackEditor/EventManager.cs
@@ -281,6 +281,7 @@ namespace SoundtrackEditor
             // TODO: Check playlists and only add the events required.
 
             /*GameEvents.onActiveJointNeedUpdate.Add(onActiveJointNeedUpdate);
+            onJointBreak
             GameEvents.OnAppFocus
             GameEvents.onAsteroidSpawned*/
             GameEvents.OnCameraChange.Add(OnCameraChange);

--- a/SoundtrackEditor/InstallChecker.cs
+++ b/SoundtrackEditor/InstallChecker.cs
@@ -1,0 +1,99 @@
+/**
+ * Based on the InstallChecker from the Kethane mod for Kerbal Space Program.
+ * https://github.com/Majiir/Kethane/blob/b93b1171ec42b4be6c44b257ad31c7efd7ea1702/Plugin/InstallChecker.cs
+ * 
+ * Original is (C) Copyright Majiir.
+ * CC0 Public Domain (http://creativecommons.org/publicdomain/zero/1.0/)
+ * http://forum.kerbalspaceprogram.com/threads/65395-CompatibilityChecker-Discussion-Thread?p=899895&viewfull=1#post899895
+ * 
+ * This file has been modified extensively and is released under the same license.
+ */
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using UnityEngine;
+
+namespace (replace with namespace)
+{
+    [KSPAddon(KSPAddon.Startup.Instantly, true)]
+    internal class Startup : MonoBehaviour
+    {
+        private void Start()
+        {
+            string v = "n/a";
+            AssemblyTitleAttribute attributes = (AssemblyTitleAttribute)Attribute.GetCustomAttribute(Assembly.GetExecutingAssembly(), typeof(AssemblyTitleAttribute), false);
+            string title = attributes?.Title;
+            if (title == null)
+            {
+                title = "TitleNotAvailable";
+            }
+            v = Assembly.GetExecutingAssembly().FullName;
+            if (v == null)
+            {
+                v = "VersionNotAvailable";
+            }
+            Debug.Log("[" + title + "] Version " + v);
+        }
+    }
+
+    [KSPAddon(KSPAddon.Startup.MainMenu, true)]
+    internal class InstallChecker : MonoBehaviour
+    {
+        private const string MODNAME = "Soundtrack Editor ";
+        private const string FOLDERNAME = "SoundtrackEditor";
+        private const string EXPECTEDPATH = FOLDERNAME + "/Plugins";
+
+        protected void Start()
+        {
+            // Search for this mod's DLL existing in the wrong location. This will also detect duplicate copies because only one can be in the right place.
+            var assemblies = AssemblyLoader.loadedAssemblies.Where(a => a.assembly.GetName().Name == Assembly.GetExecutingAssembly().GetName().Name).Where(a => a.url != EXPECTEDPATH);
+            if (assemblies.Any())
+            {
+                var badPaths = assemblies.Select(a => a.path).Select(p => Uri.UnescapeDataString(new Uri(Path.GetFullPath(KSPUtil.ApplicationRootPath)).MakeRelativeUri(new Uri(p)).ToString().Replace('/', Path.DirectorySeparatorChar)));
+                PopupDialog.SpawnPopupDialog
+                (
+                    new Vector2(0.5f, 0.5f),
+                    new Vector2(0.5f, 0.5f),
+                    "test",
+                    "Incorrect " + MODNAME + " Installation",
+                    MODNAME + " has been installed incorrectly and will not function properly. All files should be located in KSP/GameData/" + FOLDERNAME + ". Do not move any files from inside that folder.\n\nIncorrect path(s):\n" + String.Join("\n", badPaths.ToArray()),
+                    "OK",
+                    false,
+                    HighLogic.UISkin
+                );
+                Debug.Log("Incorrect " + MODNAME + " Installation: " + MODNAME + " has been installed incorrectly and will not function properly. All files should be located in KSP/GameData/" + EXPECTEDPATH + ". Do not move any files from inside that folder.\n\nIncorrect path(s):\n" + String.Join("\n", badPaths.ToArray())
+
+                     );
+
+            }
+
+            //// Check for Module Manager
+            //if (!AssemblyLoader.loadedAssemblies.Any(a => a.assembly.GetName().Name.StartsWith("ModuleManager") && a.url == ""))
+            //{
+            //    PopupDialog.SpawnPopupDialog("Missing Module Manager",
+            //        modName + " requires the Module Manager mod in order to function properly.\n\nPlease download from http://forum.kerbalspaceprogram.com/threads/55219 and copy to the KSP/GameData/ directory.",
+            //        "OK", false, HighLogic.Skin);
+            //}
+
+            CleanupOldVersions();
+        }
+
+        /*
+         * Tries to fix the install if it was installed over the top of a previous version
+         */
+        void CleanupOldVersions()
+        {
+            try
+            {
+            }
+            catch (Exception ex)
+            {
+                Debug.LogError("-ERROR- " + this.GetType().FullName + "[" + this.GetInstanceID().ToString("X") + "][" + Time.time.ToString("0.00") + "]: " +
+                   "Exception caught while cleaning up old files.\n" + ex.Message + "\n" + ex.StackTrace );
+
+            }
+        }
+    }
+}
+

--- a/SoundtrackEditor/Persistor.cs
+++ b/SoundtrackEditor/Persistor.cs
@@ -454,7 +454,7 @@ namespace SoundtrackEditor
                     if (pl.playWhen.minVesselDistance != 0)
                         preReq.AddValue("minVesselDistance", pl.playWhen.minVesselDistance);
                     if (pl.playWhen.vesselState != Enums.VesselState.Any && pl.playWhen.vesselState != 0)
-                        preReq.AddValue("vesselSituation", pl.playWhen.vesselState);
+                        preReq.AddValue("vesselState", pl.playWhen.vesselState);
                     if (pl.playWhen.scene != Enums.Scenes.Any)
                         preReq.AddValue("scene", pl.playWhen.scene.ToString().Replace(", ", " | "));
                     if (pl.playWhen.situation != Enums.AnyVesselSituation)

--- a/SoundtrackEditor/Playlist.cs
+++ b/SoundtrackEditor/Playlist.cs
@@ -355,7 +355,7 @@ namespace SoundtrackEditor
                 // Body name
                 if (bodyName.Length > 0 && !bodyName.Equals(v.mainBody.name))
                 {
-                    //Utils.Log("Prereq failed: Expected bodyName " + bodyName + ", but was " + v.mainBody.name);
+                    Utils.Log("Prereq failed: Expected bodyName " + bodyName + ", but was " + v.mainBody.name);
                     return false;
                 }
                 return true;
@@ -365,7 +365,7 @@ namespace SoundtrackEditor
             {
                 if ((v.situation & situation) != v.situation)
                 {
-                    //Utils.Log("Prereq failed: Expected situation " + situation + ", but was " + v.situation);
+                    Utils.Log("Prereq failed: Expected situation " + situation + ", but was " + v.situation);
                     return false;
                 }
                 return true;

--- a/SoundtrackEditor/SoundGui.cs
+++ b/SoundtrackEditor/SoundGui.cs
@@ -445,11 +445,21 @@ NullReferenceException: Object reference not set to an instance of an object
 
                 string label;
                 if (sted.CurrentPlaylist == playlists[i])
+                {
                     label = string.Format("<b>{0} ►</b>", playlistName);
-                else if (sted.ActivePlaylists.Contains(playlists[i]))
-                    label = string.Format("<b>{0} ☑</b>", playlistName);
+                }
                 else
+                {;
+                    if (sted.ActivePlaylists != null && sted.ActivePlaylists.Contains(playlists[i]))
+                    {
+                    label = string.Format("<b>{0} ☑</b>", playlistName);
+                    }
+                else
+                    {
                     label = string.Format("<b>{0}</b>", playlistName);
+                    }
+                }
+
                 GUILayout.Label(label);
 
                 GUILayout.FlexibleSpace();

--- a/SoundtrackEditor/SoundtrackEditor.cs
+++ b/SoundtrackEditor/SoundtrackEditor.cs
@@ -50,7 +50,7 @@ namespace SoundtrackEditor
             Instance = this;
             music = MusicLogic.fetch;
 
-            //Utils.Log("# OS Version: " + Environment.OSVersion + ", Platform: " + Environment.OSVersion.Platform);
+            Utils.Log("# OS Version: " + Environment.OSVersion + ", Platform: " + Environment.OSVersion.Platform);
             //DeleteAllStock();
 
             DontDestroyOnLoad(gameObject);
@@ -164,6 +164,9 @@ namespace SoundtrackEditor
             music.audio2.clip = emptyTrack;
 
             music.constructionPlaylist.Clear();
+            // This is a workaround to prevent a NullRef upon entering the Editor
+            music.constructionPlaylist.Add(emptyTrack);
+
             music.spacePlaylist.Clear();
             music.astroComplexAmbience = emptyTrack;
             music.credits = emptyTrack;
@@ -177,7 +180,7 @@ namespace SoundtrackEditor
             music.trackingAmbience = emptyTrack;
             music.VABAmbience = emptyTrack;
         }
-
+#if false
         private void DeleteAllStock()
         {
             List<AudioClip> allTracks = new List<AudioClip>{
@@ -193,6 +196,7 @@ namespace SoundtrackEditor
                 music.trackingAmbience,
                 music.VABAmbience
             };
+            music.constructionPlaylist.Clear();
             allTracks.AddRange(music.constructionPlaylist);
             allTracks.AddRange(music.spacePlaylist);
 
@@ -204,6 +208,7 @@ namespace SoundtrackEditor
 
             //deleted = true;
         }
+#endif
 
         private bool _loading = false;
         public void Update()
@@ -228,7 +233,7 @@ namespace SoundtrackEditor
             UpdatePlaylist();
         }
 
-        #region Playback management
+#region Playback management
 
         public void UpdateCurrentTrack()
         {
@@ -282,7 +287,7 @@ namespace SoundtrackEditor
             if (!ActivePlaylists.Contains(CurrentPlaylist))
             {
                 CurrentPlaylist = ActivePlaylists[0];
-                //Utils.Log("Switching to playlist " + ActivePlaylists[0].name + " of " + ActivePlaylists.Count + " matching playlists.");
+                Utils.Log("Switching to playlist " + ActivePlaylists[0].name + " of " + ActivePlaylists.Count + " matching playlists.");
                 SwitchToPlaylist(ActivePlaylists[0]);
             }
         }
@@ -335,11 +340,11 @@ namespace SoundtrackEditor
                 {
                     if (p.playWhen.PrerequisitesMet())
                         validPlaylists.Add(p);
-                    /*else
-                        Utils.Log("Playlist " + p.name + " failed prereqs");*/
+                    else
+                        Utils.Log("Playlist " + p.name + " failed prereqs");
                 }
-                /*else
-                    Utils.Log("Playlist " + p.name + " is disabled");*/
+                else
+                    Utils.Log("Playlist " + p.name + " is disabled");
             }
 
             // TODO: Select an appropriate playlist.
@@ -348,7 +353,7 @@ namespace SoundtrackEditor
                 return validPlaylists;
             else
             {
-                //Utils.Log("No valid playlists found!");
+                Utils.Log("No valid playlists found!");
                 return null;
             }
         }
@@ -603,7 +608,7 @@ namespace SoundtrackEditor
             }
         }
 
-        #endregion Playback management
+#endregion Playback management
 
     } // End of class.
 

--- a/SoundtrackEditor/SoundtrackEditor.csproj
+++ b/SoundtrackEditor/SoundtrackEditor.csproj
@@ -55,6 +55,7 @@
     <Compile Include="EventManager.cs" />
     <Compile Include="Fader.cs" />
     <Compile Include="GuiUtils.cs" />
+    <Compile Include="InstallChecker.cs" />
     <Compile Include="MP3Import.cs" />
     <Compile Include="MPGImport.cs" />
     <Compile Include="Persistor.cs" />

--- a/SoundtrackEditor/Utils.cs
+++ b/SoundtrackEditor/Utils.cs
@@ -1,9 +1,7 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using UnityEngine;
 using System.IO;
+using System.Diagnostics;
 
 namespace SoundtrackEditor
 {
@@ -12,9 +10,10 @@ namespace SoundtrackEditor
         public static double KscLatitude = -0.0917535863160035;
         public static double KscLongitude = 285.37030688110428;
 
+        [ConditionalAttribute("DEBUG")]
         public static void Log(string message)
         {
-            Debug.Log("[STED] " + message);
+            UnityEngine.Debug.Log("[STED] " + message);
         }
 
         public static string AssemblyDirectory


### PR DESCRIPTION
Here are all the changes I did, but not including the change to the ToolbarController, ClickthroughBlocker.
One new code file added, InstallChecker.cs
Changelog file was also added

Fixes by Linuxgurugamer:

Fixed node value being saved in Persistor.cs, line 457, was saving the vesselState as a vesselSituation
Fixed a nullref when entering the editor, nullref was because constructionPlaylist
	was empty, and it appears that the game code is assuming there is always a playlist
Fixed Nullref in SoundGui.cs when sted.ActivePlaylists was null
Added InstallChecker to validate correct installation (untested)